### PR TITLE
Adding Babylon dependency to fix #33

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/gbochenek/esri-wab-build"
   },
   "dependencies": {
+    "babylon": "^6.17.4",
     "fs-extra": "^3.0.1",
     "husky": "^0.14.1",
     "lint-staged": "^4.0.0",


### PR DESCRIPTION
Adding Babylon to package.json dependencies to fix missing module error.