### PR TITLE
added jimu/WidgetPlaceholder & jimu/OnScreenWidgetIcon to app profile

### DIFF
--- a/app/_app.profile.js
+++ b/app/_app.profile.js
@@ -97,6 +97,8 @@ profile = {
         "jimu/BaseWidget",
         "jimu/BaseWidgetFrame",
         "jimu/BaseWidgetPanel",
+        "jimu/WidgetPlaceholder",
+        "jimu/OnScreenWidgetIcon",
         "jimu/OnScreenWidgetPanel",
         "jimu/BaseWidgetSetting",
         "jimu/symbolUtils",


### PR DESCRIPTION
i found that the jimu app profile wasn't right when using 2.6 WAB. Adding this seemed to fix the issue. 
To test i started a blank app and re ran using updated branch.