### PR TITLE
Use a promise to let the caller know when the build has completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you see an error around dojo-themes, run: ```bower cache clear``` and try aga
 1. ```npm install```
 2. ```npm run build```
 
-## Install  and run globaly:
+## Install  and run globally:
 1. ```npm install -g esri-wab-build```
 2. navigate to the application to be built
 3. ```esri-wab-build```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "email": "gbochenek@esri.com"
   },
   "name": "esri-wab-build",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "Build ESRI Web App Builder Applications for performance.",
   "license": "Apache-2.0",
   "main": "app/build",


### PR DESCRIPTION
The promise resolves with path information to provide the location of the output path and the output zip file's path.

This allowed the build to be used in a gulp task in such a way that the output zip can then be copied out to a web server once it's been built.